### PR TITLE
v1.1.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,13 +29,17 @@ requirements:
     - python
 
 test:
+  source_files:
+    - tests/
   imports:
     - cmyt
     - cmyt.colormaps
   commands:
     - pip check
+    - pytest tests -v
   requires:
     - pip
+    - pytest
 
 about:
   home: https://github.com/yt-project/yt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,16 @@ test:
 about:
   home: https://github.com/yt-project/yt
   summary: A collection of Matplotlib colormaps from the yt project
+  description: |
+    Matplotlib colormaps from the yt project!
+
+    The following colormaps, as well as their respective reversed (*_r) versions are available:
+      - Perceptually uniform sequential colormaps
+      - Monochromatic sequential colormaps
+      - Miscellaneous
+
   dev_url: https://github.com/yt-project/cmyt/
+  doc_url: https://github.com/yt-project/cmyt/
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,19 +12,21 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
-    - python >=3.8
+    - python
+    - setuptools
+    - wheel
   run:
     - colorspacious >=1.1.2
     - matplotlib-base >=3.2.0
     - more-itertools >=8.4
     - numpy >=1.17.4
-    - python >=3.8
+    - python
 
 test:
   imports:


### PR DESCRIPTION
# cmyt v1.1.3

`yt` -> `cmyt`

upstream: https://github.com/yt-project/cmyt/tree/v1.1.3

## Actions
- Update to our recipe standards
- Run upstreams unit tests

## Notes
- This is a new package for defaults, necessary to build latest `yt`